### PR TITLE
Remove Debugging Stuff, Fix Pointer

### DIFF
--- a/src/tobiasdev/bungeetools/API.php
+++ b/src/tobiasdev/bungeetools/API.php
@@ -82,21 +82,6 @@ class API
         }
     }
 
-    public static function alignMessage(array $lines): ?string
-    {
-        $stickWith = max(array_map('strlen', $lines));
-        $output = "";
-        foreach ($lines as $line) {
-            $diff = round(($stickWith - strlen($line)) / 2);
-
-            if ($diff !== 0) $line = str_repeat(" ", $diff) . $line;
-
-            $output .= "{$line}\n";
-        }
-
-        return $output;
-    }
-
     public static function getRandomPlayer(): ?Player
     {
         if (count(Server::getInstance()->getOnlinePlayers()) > 0) {

--- a/src/tobiasdev/bungeetools/protocol/StringStream.php
+++ b/src/tobiasdev/bungeetools/protocol/StringStream.php
@@ -30,7 +30,7 @@ class StringStream
             // read first two length bytes
             $length = Binary::readShort($this->buffer{$this->pointer} . $this->buffer{$this->pointer + 1});
             // add 2 to pointer
-            $this->changePointer($this->pointer + 2);
+            $this->pointer += 2;
             // read length bytes far and append to string
             $d = "";
             for ($i = $this->pointer; $i < $this->pointer + $length; $i++) {
@@ -49,24 +49,22 @@ class StringStream
     {
         try {
             $offset = $this->pointer;
+            $this->pointer += 4;
             return Binary::readInt($this->buffer{$offset} . $this->buffer{$offset + 1} . $this->buffer{$offset + 2} . $this->buffer{$offset + 3});
         } catch (Exception $e) {
-            var_dump("Target Buffer: " . $this->buffer);
+         
             MainLogger::getLogger()->warning("Error while decoding int: " . $this->buffer . " ( " . $e->getMessage() . ", LINE: " . $e->getLine() . " )");
             return null;
         }
     }
 
-    public function changePointer(int $newpointer)
-    {
-        MainLogger::getLogger()->debug("Changed pointer from " . $this->pointer . " to " . $newpointer);
-        $this->pointer = $newpointer;
-    }
     public function readUnsignedShort(): ?int {
         try{
-            return Binary::readUnsignedVarInt($this->buffer, $this->pointer);
+            
+            $ret = Binary::readUnsignedVarInt($this->buffer, $this->pointer);
+            $this->pointer += 4;
+            return $ret;
         }catch (Exception $e) {
-            var_dump("Target Buffer: " . $this->buffer);
             MainLogger::getLogger()->warning("Error while decoding unsignedShort: " . $this->buffer . " ( " . $e->getMessage() . ", LINE: " . $e->getLine() . " )");
             return null;
         }


### PR DESCRIPTION
The changePointer() function was only for debugging use, as other code that existed. var_dump has nothing to do in anything near production-ready code. Pointer needed to be relocated after reading, otherwise you won't be able to read several integers after each other