### PR TITLE
Update API.php

### DIFF
--- a/src/tobiasdev/bungeetools/API.php
+++ b/src/tobiasdev/bungeetools/API.php
@@ -71,6 +71,7 @@ class API
         if (($sendthrough = static::getRandomPlayer()) != null) {
             $packet = new ScriptCustomEventPacket();
             $packet->eventName = "bungeecord:main";
+            $packet->eventData = "";
             ProtocolUtils::writeString("Message", $packet->eventData);
             ProtocolUtils::writeString($player, $packet->eventData);
             ProtocolUtils::writeString($message, $packet->eventData);


### PR DESCRIPTION
Error:
2019-08-30 06:53:00 <Server thread/Critical> TypeError: "Argument 2 passed to protocol\ProtocolUtils::writeString() must be of the type string, null given, called in phar:///root/fire/lobby/plugins/FireCore_v3.0.0.phar/src/core/API.php on line 77" (EXCEPTION) in "plugins/FireCore_v3.0.0.phar/src/protocol/ProtocolUtils" at line 9
2019-08-30 06:53:00 <Server thread/Debug> #0 plugins/FireCore_v3.0.0.phar/src/core/API(77): protocol\ProtocolUtils::writeString(string[7] Message, NULL )